### PR TITLE
Use pallet-xdns to update the Gateway TTL on finality proof submission

### DIFF
--- a/modules/multi-finality-verifier/Cargo.toml
+++ b/modules/multi-finality-verifier/Cargo.toml
@@ -27,6 +27,7 @@ sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", tag = '
 sp-runtime = { git = "https://github.com/paritytech/substrate", tag = 'monthly-2021-06' , default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", tag = 'monthly-2021-06' , default-features = false }
 sp-trie = { git = "https://github.com/paritytech/substrate", tag = 'monthly-2021-06' , default-features = false }
+pallet-xdns = { path = "../../../../circuit/src/xdns", default-features = false }
 
 [dev-dependencies]
 bp-test-utils = {path = "../../primitives/test-utils" }
@@ -49,5 +50,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-trie/std",
+	"pallet-xdns/std"
 ]
 runtime-benchmarks = []

--- a/modules/multi-finality-verifier/Cargo.toml
+++ b/modules/multi-finality-verifier/Cargo.toml
@@ -28,6 +28,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", tag = 'monthly-2
 sp-std = { git = "https://github.com/paritytech/substrate", tag = 'monthly-2021-06' , default-features = false }
 sp-trie = { git = "https://github.com/paritytech/substrate", tag = 'monthly-2021-06' , default-features = false }
 pallet-xdns = { path = "../../../../circuit/src/xdns", default-features = false }
+t3rn-primitives = { path = "../../../../circuit/src/primitives", default-features = false }
 
 [dev-dependencies]
 bp-test-utils = {path = "../../primitives/test-utils" }


### PR DESCRIPTION
This PR is a counterpart to issue #65 on the [t3rn repo](https://github.com/t3rn/t3rn/) and referenced on PR https://github.com/t3rn/t3rn/pull/69.

It adds pallet-xdns as a dependency to the multi-finality-verifier pallet and makes use of `update_ttl` function to update the XdnsRecord storage with the current block timestamp.